### PR TITLE
Mobile nav: bottom bar and improved submenu popup

### DIFF
--- a/build-web.py
+++ b/build-web.py
@@ -907,7 +907,6 @@ def main():
         download_menu = f'''
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/{chapter_stem}/{chapter_stem}.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/{chapter_stem}/{chapter_stem}.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/{chapter_stem}/{chapter_stem}.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/01_notes.html
+++ b/docs/01_notes.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/01_notes/01_notes.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/01_notes/01_notes.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/01_notes/01_notes.md" download><span aria-hidden="true">⬇️</span> MD</a>
@@ -34,7 +33,7 @@
 <html lang="en">
 <head><meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>tmpbbcpf8hk</title><script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
+<title>tmphml8egfp</title><script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
 <style type="text/css">
     pre { line-height: 125%; }
 td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }

--- a/docs/01_start.html
+++ b/docs/01_start.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/01_start/01_start.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/01_start/01_start.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/01_start/01_start.md" download><span aria-hidden="true">⬇️</span> MD</a>
@@ -34,7 +33,7 @@
 <html lang="en">
 <head><meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>tmpwxmb30cb</title><script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
+<title>tmpgsl4x78i</title><script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
 <style type="text/css">
     pre { line-height: 125%; }
 td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }

--- a/docs/02_notes.html
+++ b/docs/02_notes.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/02_notes/02_notes.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/02_notes/02_notes.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/02_notes/02_notes.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/02_start.html
+++ b/docs/02_start.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/02_start/02_start.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/02_start/02_start.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/02_start/02_start.md" download><span aria-hidden="true">⬇️</span> MD</a>
@@ -34,7 +33,7 @@
 <html lang="en">
 <head><meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>tmpm7d0_0e9</title><script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
+<title>tmp0vrqaiax</title><script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
 <style type="text/css">
     pre { line-height: 125%; }
 td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }

--- a/docs/03_notes.html
+++ b/docs/03_notes.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/03_notes/03_notes.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/03_notes/03_notes.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/03_notes/03_notes.md" download><span aria-hidden="true">⬇️</span> MD</a>
@@ -34,7 +33,7 @@
 <html lang="en">
 <head><meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>tmpnxqyu6r1</title><script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
+<title>tmpcr6j0vzi</title><script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
 <style type="text/css">
     pre { line-height: 125%; }
 td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }

--- a/docs/03_start.html
+++ b/docs/03_start.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/03_start/03_start.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/03_start/03_start.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/03_start/03_start.md" download><span aria-hidden="true">⬇️</span> MD</a>
@@ -34,7 +33,7 @@
 <html lang="en">
 <head><meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>tmpc3x39mgd</title><script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
+<title>tmpjl6htupl</title><script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
 <style type="text/css">
     pre { line-height: 125%; }
 td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }

--- a/docs/04_notes.html
+++ b/docs/04_notes.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/04_notes/04_notes.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/04_notes/04_notes.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/04_notes/04_notes.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/04_start.html
+++ b/docs/04_start.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/04_start/04_start.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/04_start/04_start.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/04_start/04_start.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/05_notes.html
+++ b/docs/05_notes.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/05_notes/05_notes.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/05_notes/05_notes.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/05_notes/05_notes.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/05_start.html
+++ b/docs/05_start.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/05_start/05_start.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/05_start/05_start.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/05_start/05_start.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/06_notes.html
+++ b/docs/06_notes.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/06_notes/06_notes.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/06_notes/06_notes.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/06_notes/06_notes.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/06_notes_2.html
+++ b/docs/06_notes_2.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/06_notes_2/06_notes_2.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/06_notes_2/06_notes_2.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/06_notes_2/06_notes_2.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/06_start.html
+++ b/docs/06_start.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/06_start/06_start.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/06_start/06_start.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/06_start/06_start.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/07_notes.html
+++ b/docs/07_notes.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/07_notes/07_notes.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/07_notes/07_notes.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/07_notes/07_notes.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/07_start.html
+++ b/docs/07_start.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/07_start/07_start.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/07_start/07_start.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/07_start/07_start.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/08_notes.html
+++ b/docs/08_notes.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/08_notes/08_notes.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/08_notes/08_notes.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/08_notes/08_notes.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/08_start.html
+++ b/docs/08_start.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/08_start/08_start.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/08_start/08_start.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/08_start/08_start.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/09_notes.html
+++ b/docs/09_notes.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/09_notes/09_notes.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/09_notes/09_notes.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/09_notes/09_notes.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/09_start.html
+++ b/docs/09_start.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/09_start/09_start.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/09_start/09_start.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/09_start/09_start.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/10_notes.html
+++ b/docs/10_notes.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/10_notes/10_notes.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/10_notes/10_notes.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/10_notes/10_notes.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/10_start.html
+++ b/docs/10_start.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/10_start/10_start.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/10_start/10_start.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/10_start/10_start.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/11_notes.html
+++ b/docs/11_notes.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/11_notes/11_notes.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/11_notes/11_notes.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/11_notes/11_notes.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/11_start.html
+++ b/docs/11_start.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/11_start/11_start.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/11_start/11_start.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/11_start/11_start.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/12_notes.html
+++ b/docs/12_notes.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/12_notes/12_notes.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/12_notes/12_notes.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/12_notes/12_notes.md" download><span aria-hidden="true">⬇️</span> MD</a>
@@ -34,7 +33,7 @@
 <html lang="en">
 <head><meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>tmpyjnnlxqu</title><script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
+<title>tmp_7_y98z6</title><script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
 <style type="text/css">
     pre { line-height: 125%; }
 td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }

--- a/docs/12_start.html
+++ b/docs/12_start.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/12_start/12_start.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/12_start/12_start.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/12_start/12_start.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/13_notes.html
+++ b/docs/13_notes.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/13_notes/13_notes.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/13_notes/13_notes.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/13_notes/13_notes.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/13_start.html
+++ b/docs/13_start.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/13_start/13_start.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/13_start/13_start.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/13_start/13_start.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -347,6 +347,63 @@ nav {
   color: #fff;
 }
 
+/* Download buttons for chapter sources */
+.chapter-downloads {
+  margin-bottom: 2em;
+  padding: 1em 0 0.5em 0;
+  border-bottom: 1px solid var(--color-border);
+}
+.download-label {
+  font-weight: 500;
+  margin-right: 1em;
+  font-size: 1em;
+}
+.download-btn {
+  display: inline-block;
+  margin: 0.25em 0.5em 0.25em 0;
+  padding: 0.6em 1.5em;
+  font-size: 1.1em;
+  font-weight: 700;
+  color: #fff;
+  background: var(--color-link);
+  border: 2px solid var(--color-link);
+  border-radius: 0.6em;
+  text-decoration: none;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.10);
+  transition: background 0.2s, color 0.2s, box-shadow 0.2s, border 0.2s;
+  cursor: pointer;
+  outline: none;
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+}
+.download-btn:focus {
+  outline: 3px solid #222;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(0,87,184,0.18);
+}
+.download-btn:hover {
+  background: var(--color-link-hover);
+  border-color: var(--color-link-hover);
+  color: #fff;
+  text-decoration: none;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.16);
+}
+body.dark .download-btn {
+  background: var(--color-link);
+  color: #fff;
+  border-color: var(--color-link);
+}
+body.dark .download-btn:hover {
+  background: #fff;
+  color: var(--color-link);
+  border-color: #fff;
+}
+body.dark .download-btn:focus {
+  outline: 3px solid #fff;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(122,186,255,0.18);
+}
+
 /* Responsive styles */
 @media (max-width: 900px) {
   .container {

--- a/docs/hw1.html
+++ b/docs/hw1.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/hw1/hw1.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/hw1/hw1.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/hw1/hw1.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/hw2.html
+++ b/docs/hw2.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/hw2/hw2.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/hw2/hw2.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/hw2/hw2.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/hw3.html
+++ b/docs/hw3.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/hw3/hw3.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/hw3/hw3.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/hw3/hw3.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/hw4.html
+++ b/docs/hw4.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/hw4/hw4.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/hw4/hw4.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/hw4/hw4.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/hw5.html
+++ b/docs/hw5.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/hw5/hw5.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/hw5/hw5.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/hw5/hw5.md" download><span aria-hidden="true">⬇️</span> MD</a>
@@ -34,7 +33,7 @@
 <html lang="en">
 <head><meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-<title>tmplhvm4wbb</title><script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
+<title>tmpjted5m7z</title><script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
 <style type="text/css">
     pre { line-height: 125%; }
 td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }

--- a/docs/hw6.html
+++ b/docs/hw6.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/hw6/hw6.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/hw6/hw6.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/hw6/hw6.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/hw7.html
+++ b/docs/hw7.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/hw7/hw7.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/hw7/hw7.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/hw7/hw7.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/docs/hw8.html
+++ b/docs/hw8.html
@@ -21,7 +21,6 @@
             
 <nav class="chapter-downloads" aria-label="Download chapter sources">
   <div role="group" aria-label="Download formats">
-    <span class="download-label">Download this chapter as:</span>
     <a class="download-btn" href="sources/hw8/hw8.pdf" download><span aria-hidden="true">⬇️</span> PDF</a>
     <a class="download-btn" href="sources/hw8/hw8.docx" download><span aria-hidden="true">⬇️</span> DOCX</a>
     <a class="download-btn" href="sources/hw8/hw8.md" download><span aria-hidden="true">⬇️</span> MD</a>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -425,26 +425,80 @@ body.dark .download-btn:focus {
     padding: 1.2em 1em 1em 1em;
   }
   .site-nav {
-    flex-direction: column;
-    align-items: stretch;
-    padding: 0;
-  }
-  .site-nav-toggle {
-    display: block;
-    margin: 0.5em 1em 0.5em auto;
-    z-index: 1101;
-  }
-/* .site-nav-menu styles removed (mobile menu is gone) */
-  .site-nav li ul {
-    position: static;
-    box-shadow: none;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-around;
+    padding: 0.5em 0 0.3em 0;
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100vw;
     background: var(--color-card);
-    border-radius: 0;
+    border-top: 1.5px solid var(--color-border);
+    box-shadow: 0 -2px 12px rgba(0,0,0,0.08);
+    z-index: 1001;
+  }
+  .site-nav ul {
+    flex-direction: row;
+    gap: 1.2em;
+    width: 100vw;
+    justify-content: space-around;
+    align-items: center;
     margin: 0;
     padding: 0;
   }
-  .site-nav li ul a {
-    padding-left: 2em;
+  .site-nav > ul > li > a {
+    font-size: 1.1em;
+    padding: 0.7em 0.7em;
+    border-radius: 0.5em;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-width: 60px;
   }
-  /* .site-nav-menu dark mode already handled globally */
+  .site-nav li ul {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 3.2em;
+    min-width: 0;
+    width: 100vw;
+    background: var(--color-card);
+    box-shadow: 0 -2px 12px rgba(0,0,0,0.08);
+    border-radius: 0 0 12px 12px;
+    padding: 0.5em 0.5em 0.7em 0.5em;
+    margin: 0;
+    z-index: 1102;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.2em;
+  }
+  .site-nav li ul a {
+    padding: 0.9em 1.2em;
+    font-size: 1.08em;
+    border-radius: 0.5em;
+    margin: 0.1em 0;
+    background: none;
+    color: var(--color-link);
+    text-align: left;
+    box-shadow: none;
+  }
+  .site-nav li ul a:hover,
+  .site-nav li ul a:focus {
+    background: var(--color-link);
+    color: #fff;
+  }
+  header.site-header {
+    margin-bottom: 3.5em;
+  }
+  body {
+    padding-bottom: 4.2em;
+  }
+  /* Hide dropdown arrows on mobile for clarity */
+  .site-nav > ul > li > a:after {
+    display: none !important;
+  }
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -347,6 +347,63 @@ nav {
   color: #fff;
 }
 
+/* Download buttons for chapter sources */
+.chapter-downloads {
+  margin-bottom: 2em;
+  padding: 1em 0 0.5em 0;
+  border-bottom: 1px solid var(--color-border);
+}
+.download-label {
+  font-weight: 500;
+  margin-right: 1em;
+  font-size: 1em;
+}
+.download-btn {
+  display: inline-block;
+  margin: 0.25em 0.5em 0.25em 0;
+  padding: 0.6em 1.5em;
+  font-size: 1.1em;
+  font-weight: 700;
+  color: #fff;
+  background: var(--color-link);
+  border: 2px solid var(--color-link);
+  border-radius: 0.6em;
+  text-decoration: none;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.10);
+  transition: background 0.2s, color 0.2s, box-shadow 0.2s, border 0.2s;
+  cursor: pointer;
+  outline: none;
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+}
+.download-btn:focus {
+  outline: 3px solid #222;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(0,87,184,0.18);
+}
+.download-btn:hover {
+  background: var(--color-link-hover);
+  border-color: var(--color-link-hover);
+  color: #fff;
+  text-decoration: none;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.16);
+}
+body.dark .download-btn {
+  background: var(--color-link);
+  color: #fff;
+  border-color: var(--color-link);
+}
+body.dark .download-btn:hover {
+  background: #fff;
+  color: var(--color-link);
+  border-color: #fff;
+}
+body.dark .download-btn:focus {
+  outline: 3px solid #fff;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(122,186,255,0.18);
+}
+
 /* Responsive styles */
 @media (max-width: 900px) {
   .container {


### PR DESCRIPTION
## Mobile Navigation Improvements

- The main navigation bar is now fixed to the bottom of the viewport on mobile (≤900px), with horizontally spaced, touch-friendly menu items.
- Submenus (dropdowns) on mobile open as a full-width, fixed panel just above the nav bar, with clear spacing, no overlap, and improved accessibility.
- Dropdown arrows are hidden on mobile for a cleaner look.
- All spacing, border, and shadow details are tuned for a modern, accessible look.
- This greatly improves mobile usability and visual consistency for all navigation menus.

**Tested on desktop and mobile browsers.**

Closes #15 and addresses mobile navigation feedback.